### PR TITLE
Edit redirect

### DIFF
--- a/frontend/components/stories/story_form_container.js
+++ b/frontend/components/stories/story_form_container.js
@@ -3,12 +3,14 @@ import StoryForm from './story_form';
 import { createStory, updateStory, fetchStory } from '../../actions/story_actions';
 import { clearErrors } from '../../actions/error_actions';
 
-const mapStateToProps = (state, ownProps) => ({
-  currentUser: state.session.currentUser,
-  story: state.stories[ownProps.match.params.storyId],
-  formType: ownProps.formType,
-  errors: state.errors
-});
+const mapStateToProps = (state, ownProps) => {
+  return ({
+    currentUser: state.session.currentUser,
+    story: state.stories[ownProps.match.params.storyId],
+    formType: ownProps.match.params.storyId ? "edit" : "new",
+    errors: state.errors
+  })
+};
 
 const mapDispatchToProps = (dispatch) => ({
   createStory: (story) => dispatch(createStory(story)),


### PR DESCRIPTION
- Validate story owner ship clientside in case of direct access to /edit
- redirect to /stories/:id if not authorized to edit
- pass formType as props rather than local state
- fix a bunch of issues with prefilling/clearing form correctly when switching from /new to /edit and going back and forward in browser